### PR TITLE
Update init.luau

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -95,9 +95,6 @@ local function LoadControllersAsync(controllers: { Types.Controller<any> })
 		for _, lifecycle in Lifecycles do
 			if (controller :: any)[lifecycle.Name] then
 				table.insert(lifecycle.Listeners, (controller :: any)[lifecycle.Name])
-				if DefaultLifecycles[lifecycle.Name] then
-					LoadDefaultLifecycle(lifecycle)
-				end
 			end
 		end
 
@@ -121,6 +118,13 @@ local function LoadControllersAsync(controllers: { Types.Controller<any> })
 		-- Call start on all dependencies
 		if controller.Start then
 			LoadController(controller.Start, "Start")
+		end
+	end
+
+	-- Connect default lifecycles
+	for _, lifecycle in Lifecycles do
+		if DefaultLifecycles[lifecycle.Name] then
+			LoadDefaultLifecycle(lifecycle)
 		end
 	end
 end


### PR DESCRIPTION
fixes default lifecyle memory leak from overconnecting

## Summary

<!-- Summarize your changes here -->
i moved the connection to default lifecycle events outside of the for loop inside of loadcontrollersasync and made a new for loop after it, this will probably be best to make a separate function for it, but this also works.

## Checks

By submitting your pull request for review, you agree to the following:

- [x] I give full permission for maintainers and contributors of this repository to change my code in any way.
- [x] I am open to this pull request being a part of a completely open source repository which can be modified at any time, and I abide by the license terms.
- [x] To the best of my knowledge, there are no issues present in this pull request.